### PR TITLE
Display only geofence notifications in foreground

### DIFF
--- a/src/ios/GeofencePlugin.swift
+++ b/src/ios/GeofencePlugin.swift
@@ -625,8 +625,12 @@ class GeoNotificationManager : NSObject, CLLocationManagerDelegate, UNUserNotifi
     func userNotificationCenter(_ center: UNUserNotificationCenter,
                                 willPresent notification: UNNotification,
                                 withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        // Play sound and show alert to the user
-        completionHandler([.alert,.sound])
+        if notification.request.content.userInfo["geofence.notification.data"] != nil {
+            // Play sound and show alert to the user if it is a geofence notification
+            completionHandler([.alert,.sound])
+        } else {
+            completionHandler([])
+        }
     }
     
     @available(iOS 10.0, *)


### PR DESCRIPTION
Ignore manage other notifications. By default foreground notifications don't appear. With this fix it will display only geofence notifications in foreground.